### PR TITLE
Awk that ships BigSur 11.1 (air M1) errors out (awk version 20200816)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 ***ListProvisioningProfileName*** is a simple shell script to list all the names of the provisioning profile of apple development in a folder
 
 ## Usage
+- Download gawk
+```sh
+brew install gawk
+```
+
 - Create `bin` folder in you home dir
 ```sh
 mkdir ~/bin

--- a/list-provisioning-profile-name.sh
+++ b/list-provisioning-profile-name.sh
@@ -24,4 +24,4 @@ END {
 EOF
 
 
-awk -v "provisioningProfile=$1" "$script" *
+gawk -v "provisioningProfile=$1" "$script" *


### PR DESCRIPTION
```
��W0�W1legal byte sequence 0�W(	*�H��
       0	+
 input record number 1, file 691c8c5f-81f6-49c3-b89b-8081eb74c629.mobileprovision
 source line number 5
```

Replacing awk with gawk runs the script fine.